### PR TITLE
shrink map

### DIFF
--- a/app/views/offer/show.html.erb
+++ b/app/views/offer/show.html.erb
@@ -41,10 +41,10 @@
                 <%= @offer.amount %>
                 <%= @offer.unit %>
               </p>
-            </div>
+           </div>
 
 
-            <div>
+
               <a href="/checkout" class="btn o-button"> Take that offer </a>
             </div>
 
@@ -55,7 +55,14 @@
 <!-- terceira coluna -->
 
       <div class="col-sm">
-      <%= image_tag('map.png', :size => "400x310") %>
+        <div
+          id="map"
+          style="width: 400px;
+          height: 310px;"
+          data-markers="<%= @markers.to_json %>"
+          data-mapbox-api-key="<%= ENV['MAPBOX_API_KEY'] %>"
+        </div>
+
         <div><p> <%= @offer.location %> </p></div>
       </div>
 
@@ -63,21 +70,15 @@
           <%= link_to "Back to offers", offer_index_path, class: "btn" %>
       </div>
 
-
-
-
-
     </div>
   </div>
 </div>
 
 
-<div
-  id="map"
-  style="width: 100%;
-  height: 600px;"
-  data-markers="<%= @markers.to_json %>"
-  data-mapbox-api-key="<%= ENV['MAPBOX_API_KEY'] %>"
-></div>
 
 
+<%#=        id="map"
+<%#=        size: "400x310"
+<%#=        data-markers="<%= @markers.to_json %>
+<%#=        data-mapbox-api-key="<%= ENV['MAPBOX_API_KEY'] %>
+<%#=      <%= image_tag('map.png', :size => "400x310") %>


### PR DESCRIPTION
In the show offer page, suppressed large map at page bottom, moved to a smaller card.

In my PC the columns are not nicely aligned.  Sad.